### PR TITLE
avoid mangling/including tmp.XXXXXXXX in tar base path

### DIFF
--- a/3scale-dump.sh
+++ b/3scale-dump.sh
@@ -1199,7 +1199,7 @@ if [[ -f ${CURRENT_DIR}/3scale-dump-logs.txt ]]; then
     /bin/cp -f ${CURRENT_DIR}/3scale-dump-logs.txt ${DUMP_DIR}/3scale-dump-logs.txt
 fi
 
-tar cpf ${DUMP_FILE} --xform s:'./':: ${DUMP_DIR}
+tar cpf ${DUMP_FILE} ${DUMP_DIR}
 
 if [[ ! -f ${DUMP_FILE} ]]; then
     MSG="There was an error creating ${DUMP_FILE}"


### PR DESCRIPTION
As it was, the base path for extracted files was ending up tmtmp.XXXXXXXX because of the xform param passed to tar command.

Complements the previous change which uses unique temp dir for each run.  This is especially important since this version of script is being used for OSD tiered access where the "current" dir would naturally be /root.